### PR TITLE
Feature - Added support for HTTP DELETE method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ nbdist/
 .DS_Store
 **.swap
 ~          
+
+# Eclipse #
+/bin/

--- a/docs/release/api-guide.html
+++ b/docs/release/api-guide.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 1.5.3">
+<meta name="generator" content="Asciidoctor 1.5.6.1">
 <title>Parrot-REST API Guide</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
@@ -17,7 +17,6 @@ audio:not([controls]){display:none;height:0}
 [hidden],template{display:none}
 script{display:none!important}
 html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-body{margin:0}
 a{background:transparent}
 a:focus{outline:thin dotted}
 a:active,a:hover{outline:0}
@@ -52,7 +51,7 @@ textarea{overflow:auto;vertical-align:top}
 table{border-collapse:collapse;border-spacing:0}
 *,*:before,*:after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
 html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
 a:hover{cursor:pointer}
 img,object,embed{max-width:100%;height:auto}
 object,embed{height:100%}
@@ -64,7 +63,6 @@ img{-ms-interpolation-mode:bicubic}
 .text-center{text-align:center!important}
 .text-justify{text-align:justify!important}
 .hide{display:none}
-body{-webkit-font-smoothing:antialiased}
 img,object,svg{display:inline-block;vertical-align:middle}
 textarea{height:auto;min-height:50px}
 select{width:100%}
@@ -91,13 +89,12 @@ strong,b{font-weight:bold;line-height:inherit}
 small{font-size:60%;line-height:inherit}
 code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
 ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol,ul.no-bullet,ol.no-bullet{margin-left:1.5em}
+ul,ol{margin-left:1.5em}
 ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
 ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
 ul.square{list-style-type:square}
 ul.circle{list-style-type:circle}
 ul.disc{list-style-type:disc}
-ul.no-bullet{list-style:none}
 ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
 dl dt{margin-bottom:.3125em;font-weight:bold}
 dl dd{margin-bottom:1.25em}
@@ -119,18 +116,25 @@ table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:
 table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
 table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
 table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-body{tab-size:4}
 h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
 h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
 .clearfix:before,.clearfix:after,.float-group:before,.float-group:after{content:" ";display:table}
 .clearfix:after,.float-group:after{clear:both}
-*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+*:not(pre)>code.nobreak{word-wrap:normal}
+*:not(pre)>code.nowrap{white-space:nowrap}
 pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
+em em{font-style:normal}
+strong strong{font-weight:400}
 .keyseq{color:rgba(51,51,51,.8)}
 kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
 .keyseq kbd:first-child{margin-left:0}
 .keyseq kbd:last-child{margin-right:0}
-.menuseq,.menu{color:rgba(0,0,0,.8)}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
 b.button:before,b.button:after{position:relative;top:-1px;font-weight:400}
 b.button:before{content:"[";padding:0 3px 0 2px}
 b.button:after{content:"]";padding:0 2px 0 3px}
@@ -197,7 +201,7 @@ table.tableblock>caption.title{white-space:nowrap;overflow:visible;max-width:0}
 table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
 .admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
 .admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon img{max-width:initial}
 .admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
 .admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
 .admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
@@ -253,13 +257,13 @@ table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
 table.tableblock{max-width:100%;border-collapse:separate}
 table.tableblock td>.paragraph:last-child p>p:last-child,table.tableblock th>p:last-child,table.tableblock td>p:last-child{margin-bottom:0}
 table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all th.tableblock,table.grid-all td.tableblock{border-width:0 1px 1px 0}
-table.grid-all tfoot>tr>th.tableblock,table.grid-all tfoot>tr>td.tableblock{border-width:1px 1px 0 0}
-table.grid-cols th.tableblock,table.grid-cols td.tableblock{border-width:0 1px 0 0}
-table.grid-all *>tr>.tableblock:last-child,table.grid-cols *>tr>.tableblock:last-child{border-right-width:0}
-table.grid-rows th.tableblock,table.grid-rows td.tableblock{border-width:0 0 1px 0}
-table.grid-all tbody>tr:last-child>th.tableblock,table.grid-all tbody>tr:last-child>td.tableblock,table.grid-all thead:last-child>tr>th.tableblock,table.grid-rows tbody>tr:last-child>th.tableblock,table.grid-rows tbody>tr:last-child>td.tableblock,table.grid-rows thead:last-child>tr>th.tableblock{border-bottom-width:0}
-table.grid-rows tfoot>tr>th.tableblock,table.grid-rows tfoot>tr>td.tableblock{border-width:1px 0 0 0}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px 0}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
 table.frame-all{border-width:1px}
 table.frame-sides{border-width:0 1px}
 table.frame-topbot{border-width:1px 0}
@@ -280,10 +284,12 @@ ul li ol{margin-left:1.5em}
 dl dd{margin-left:1.125em}
 dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
 ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.unstyled,ol.unnumbered,ul.checklist,ul.none{list-style-type:none}
-ul.unstyled,ol.unnumbered,ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1em;font-size:.85em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{width:1em;position:relative;top:1px}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
 ul.inline{margin:0 auto .625em auto;margin-left:-1.375em;margin-right:0;padding:0;list-style:none;overflow:hidden}
 ul.inline>li{list-style:none;float:left;margin-left:1.375em;display:block}
 ul.inline>li>*{display:block}
@@ -300,7 +306,8 @@ ol.lowergreek{list-style-type:lower-greek}
 td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
 td.hdlist1{font-weight:bold;padding-bottom:1.25em}
 .literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist>table tr>td:first-of-type{padding:0 .75em;line-height:1}
+.colist>table tr>td:first-of-type{padding:.4em .75em 0 .75em;line-height:1;vertical-align:top}
+.colist>table tr>td:first-of-type img{max-width:initial}
 .colist>table tr>td:last-of-type{padding:.25em 0}
 .thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
 .imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
@@ -363,6 +370,7 @@ div.unbreakable{page-break-inside:avoid}
 .yellow{color:#bfbf00}
 .yellow-background{background-color:#fafa00}
 span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
 .admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
 .admonitionblock td.icon .icon-note:before{content:"\f05a";color:#19407c}
 .admonitionblock td.icon .icon-tip:before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
@@ -416,7 +424,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 .hide-for-print{display:none!important}
 .show-for-print{display:inherit!important}}
 </style>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css">
 </head>
 <body class="book toc2 toc-left">
 <div id="header">
@@ -452,6 +460,25 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_curl_request_3">CURL request</a></li>
 </ul>
 </li>
+<li><a href="#resources-forget">Forget</a></li>
+<li><a href="#resources-forget-access">Accessing the forget</a>
+<ul class="sectlevel2">
+<li><a href="#forget-existing-resource">Forget an existing resource</a>
+<ul class="sectlevel3">
+<li><a href="#_example_response_4">Example response</a></li>
+<li><a href="#_example_request_4">Example request</a></li>
+<li><a href="#_curl_request_4">CURL request</a></li>
+</ul>
+</li>
+<li><a href="#forget-non-existing-resource">Forget a non-existing resource</a>
+<ul class="sectlevel3">
+<li><a href="#_example_response_5">Example response</a></li>
+<li><a href="#_example_request_5">Example request</a></li>
+<li><a href="#_curl_request_5">CURL request</a></li>
+</ul>
+</li>
+</ul>
+</li>
 </ul>
 </li>
 </ul>
@@ -484,6 +511,10 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>POST</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Used to create a new resource</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>DELETE</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Used to delete a resource</p></td>
 </tr>
 </tbody>
 </table>
@@ -550,7 +581,7 @@ use of HTTP status codes.</p>
 <h3 id="_example_response"><a class="link" href="#_example_response">Example response</a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: text/plain;charset=ISO-8859-1
 Content-Length: 57
 
@@ -562,7 +593,7 @@ I'm a healthy parrot, do you have sunflower seeds for me?</code></pre>
 <h3 id="_example_request"><a class="link" href="#_example_request">Example request</a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /health HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /health HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -571,7 +602,7 @@ Host: localhost:8080</code></pre>
 <h3 id="_curl_request"><a class="link" href="#_curl_request">CURL request</a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/health' -i</code></pre>
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/health' -i</code></pre>
 </div>
 </div>
 </div>
@@ -593,7 +624,7 @@ Host: localhost:8080</code></pre>
 <h3 id="_example_response_2"><a class="link" href="#_example_response_2">Example response</a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: text/plain;charset=ISO-8859-1
 Content-Length: 2
 
@@ -605,10 +636,10 @@ OK</code></pre>
 <h3 id="_example_request_2"><a class="link" href="#_example_request_2">Example request</a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /listen HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /listen HTTP/1.1
 Content-Type: application/hal+json
 Host: localhost:8080
-Content-Length: 114
+Content-Length: 110
 
 {
   "appContext" : "appContext",
@@ -622,7 +653,7 @@ Content-Length: 114
 <h3 id="_curl_request_2"><a class="link" href="#_curl_request_2">CURL request</a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/listen' -i -X POST -H 'Content-Type: application/hal+json' -d '{
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/listen' -i -X POST -H 'Content-Type: application/hal+json' -d '{
   "appContext" : "appContext",
   "url" : "path",
   "response" : "{\"id\": 1, \"name\": \"Test response\"}"
@@ -648,9 +679,9 @@ Content-Length: 114
 <h3 id="_example_response_3"><a class="link" href="#_example_response_3">Example response</a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: text/plain;charset=ISO-8859-1
-Content-Length: 45
+Content-Length: 42
 
 {
   "id" : 1,
@@ -663,7 +694,7 @@ Content-Length: 45
 <h3 id="_example_request_3"><a class="link" href="#_example_request_3">Example request</a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /talk/appContext/path HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /talk/appContext/path HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -672,7 +703,87 @@ Host: localhost:8080</code></pre>
 <h3 id="_curl_request_3"><a class="link" href="#_curl_request_3">CURL request</a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/talk/appContext/path' -i</code></pre>
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/talk/appContext/path' -i</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="resources-forget"><a class="link" href="#resources-forget">Forget</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The forget provides the ability to remove existing responses which were posted by the listen resource.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="resources-forget-access"><a class="link" href="#resources-forget-access">Accessing the forget</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>A <code>DLETE</code> request is used to access the forget</p>
+</div>
+<div class="sect2">
+<h3 id="forget-existing-resource"><a class="link" href="#forget-existing-resource">Forget an existing resource</a></h3>
+<div class="sect3">
+<h4 id="_example_response_4"><a class="link" href="#_example_response_4">Example response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: text/plain;charset=ISO-8859-1
+Content-Length: 2
+
+OK</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_example_request_4"><a class="link" href="#_example_request_4">Example request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /forget/appContext/path HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_curl_request_4"><a class="link" href="#_curl_request_4">CURL request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/forget/appContext/path' -i -X DELETE</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="forget-non-existing-resource"><a class="link" href="#forget-non-existing-resource">Forget a non-existing resource</a></h3>
+<div class="sect3">
+<h4 id="_example_response_5"><a class="link" href="#_example_response_5">Example response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content
+Content-Type: text/plain;charset=ISO-8859-1
+Content-Length: 10
+
+NO_CONTENT</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_example_request_5"><a class="link" href="#_example_request_5">Example request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /forget/appContext/pathDoesNotExist HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_curl_request_5"><a class="link" href="#_curl_request_5">CURL request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/forget/appContext/pathDoesNotExist' -i -X DELETE</code></pre>
+</div>
 </div>
 </div>
 </div>
@@ -681,8 +792,11 @@ Host: localhost:8080</code></pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-11-20 03:51:02 EST
+Last updated 2019-01-03 12:57:05 EST
 </div>
 </div>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+<script>hljs.initHighlighting()</script>
 </body>
 </html>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<junit.version>4.12</junit.version>
 		<start-class>parrot.rest.ParrotRestApplication</start-class>
 		<docker.image.name>parrot-rest</docker.image.name>
-		<asciidoctor-plugin.version>1.5.3</asciidoctor-plugin.version>
+		<asciidoctor-plugin.version>1.5.6</asciidoctor-plugin.version>
 		<snippetsDirectory>${project.build.directory}/snippets</snippetsDirectory>
 		<asciidoc.source.dir>src/main/asciidocs</asciidoc.source.dir>
 		<asciidoc.output.dir>docs/release</asciidoc.output.dir>

--- a/src/main/asciidocs/api-guide.adoc
+++ b/src/main/asciidocs/api-guide.adoc
@@ -22,6 +22,9 @@ Parrot-REST application is a simple application that exposes to RESTs endpoints.
 
 | `POST`
 | Used to create a new resource
+
+|`DELETE`
+| Used to delete a resource
 |===
 
 Parrot-REST tries to adhere as closely as possible to standard HTTP and REST conventions in its
@@ -117,3 +120,46 @@ include::{snippets}/talk-example/http-request.adoc[]
 === CURL request
 
 include::{snippets}/talk-example/curl-request.adoc[]
+
+[[resources-forget]]
+== Forget
+
+The forget provides the ability to remove existing responses which were posted by the listen resource.
+
+[[resources-forget-access]]
+== Accessing the forget
+
+A `DLETE` request is used to access the forget
+
+[[forget-existing-resource]]
+=== Forget an existing resource
+
+==== Example response
+
+include::{snippets}/forget-example/http-response.adoc[]
+
+==== Example request
+
+include::{snippets}/forget-example/http-request.adoc[]
+
+==== CURL request
+
+include::{snippets}/forget-example/curl-request.adoc[]
+
+[[forget-non-existing-resource]]
+=== Forget a non-existing resource
+
+==== Example response
+
+include::{snippets}/forget-non-existing-resource-example/http-response.adoc[]
+
+==== Example request
+
+include::{snippets}/forget-non-existing-resource-example/http-request.adoc[]
+
+==== CURL request
+
+include::{snippets}/forget-non-existing-resource-example/curl-request.adoc[]
+
+
+ 

--- a/src/main/java/parrot/rest/common/PhraseUtility.java
+++ b/src/main/java/parrot/rest/common/PhraseUtility.java
@@ -1,0 +1,44 @@
+package parrot.rest.common;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.web.servlet.HandlerMapping;
+
+/**
+ * 
+ * @author Isuru Weerasooriya
+ *
+ */
+public class PhraseUtility {
+
+	private PhraseUtility() {
+	}
+
+	public static String getFullUrl(HttpServletRequest request, Pattern urlPattern) {
+		StringBuilder builder = new StringBuilder();
+		String fullUrl = (String) request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
+		String url = getAppContextUrl(fullUrl, urlPattern);
+		if (url == null) {
+			return null;
+		}
+		builder.append(url);
+		if (StringUtils.isNotEmpty(request.getQueryString())) {
+			builder.append("?");
+			builder.append(request.getQueryString());
+		}
+		return builder.toString();
+	}
+
+	public static String getAppContextUrl(String fullUrl, Pattern urlPattern) {
+		Matcher matcher = urlPattern.matcher(fullUrl);
+		if (matcher.matches() && matcher.groupCount() > 0) {
+			return matcher.group(1);
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/parrot/rest/controller/ForgetController.java
+++ b/src/main/java/parrot/rest/controller/ForgetController.java
@@ -1,9 +1,11 @@
 package parrot.rest.controller;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,10 +13,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.HandlerMapping;
 
-import parrot.rest.common.Phrase;
 import parrot.rest.exception.UrlNotFoundException;
 import parrot.rest.service.PhraseService;
 
@@ -22,19 +22,50 @@ import parrot.rest.service.PhraseService;
 public class ForgetController {
 
 	public static final String PATH = "forget";
-	
+
 	private static final Logger logger = LoggerFactory.getLogger(ForgetController.class);
+	private static final Pattern URL_PATTERN = Pattern.compile("\\/{0,1}forget\\/(.*)");
 
 	@Autowired
 	private PhraseService phraseService;
-	
-	@DeleteMapping("delete/**")
-	public ResponseEntity<String> forget(@RequestBody Phrase phrase) throws UrlNotFoundException {
-		logger.debug("Deleting phrase: {}", phrase);
-		phraseService.remove(phrase.getUrl());
-		return new ResponseEntity<>("NO_CONTENT", HttpStatus.NO_CONTENT);
-		
-	}
-	
-}
 
+	@DeleteMapping("forget/**")
+	public ResponseEntity<String> talk(HttpServletRequest request) {
+		ResponseEntity<String> result = null;
+		String url = getFullUrl(request);
+
+		logger.debug("Forgetting URL: {}", url);
+		try {
+			phraseService.remove(url);
+			result = new ResponseEntity<>("OK", HttpStatus.OK);
+		} catch (UrlNotFoundException e) {
+			result = new ResponseEntity<>("NO_CONTENT", HttpStatus.NO_CONTENT);
+		}
+		return result;
+
+	}
+
+	private String getFullUrl(HttpServletRequest request) {
+		StringBuilder builder = new StringBuilder();
+		String fullUrl = (String) request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
+		String url = getAppContextUrl(fullUrl);
+		if (url == null) {
+			return null;
+		}
+		builder.append(url);
+		if (StringUtils.isNotEmpty(request.getQueryString())) {
+			builder.append("?");
+			builder.append(request.getQueryString());
+		}
+		return builder.toString();
+	}
+
+	private String getAppContextUrl(String fullUrl) {
+		Matcher matcher = URL_PATTERN.matcher(fullUrl);
+		if (matcher.matches() && matcher.groupCount() > 0) {
+			return matcher.group(1);
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/parrot/rest/controller/ForgetController.java
+++ b/src/main/java/parrot/rest/controller/ForgetController.java
@@ -1,11 +1,9 @@
 package parrot.rest.controller;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,11 +11,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.servlet.HandlerMapping;
 
+import parrot.rest.common.PhraseUtility;
 import parrot.rest.exception.UrlNotFoundException;
 import parrot.rest.service.PhraseService;
 
+/**
+ * 
+ * @author Isuru Weerasooriya
+ *
+ */
 @Controller(ForgetController.PATH)
 public class ForgetController {
 
@@ -32,7 +35,7 @@ public class ForgetController {
 	@DeleteMapping("forget/**")
 	public ResponseEntity<String> talk(HttpServletRequest request) {
 		ResponseEntity<String> result = null;
-		String url = getFullUrl(request);
+		String url = PhraseUtility.getFullUrl(request, URL_PATTERN);
 
 		logger.debug("Forgetting URL: {}", url);
 		try {
@@ -42,30 +45,6 @@ public class ForgetController {
 			result = new ResponseEntity<>("NO_CONTENT", HttpStatus.NO_CONTENT);
 		}
 		return result;
-
-	}
-
-	private String getFullUrl(HttpServletRequest request) {
-		StringBuilder builder = new StringBuilder();
-		String fullUrl = (String) request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
-		String url = getAppContextUrl(fullUrl);
-		if (url == null) {
-			return null;
-		}
-		builder.append(url);
-		if (StringUtils.isNotEmpty(request.getQueryString())) {
-			builder.append("?");
-			builder.append(request.getQueryString());
-		}
-		return builder.toString();
-	}
-
-	private String getAppContextUrl(String fullUrl) {
-		Matcher matcher = URL_PATTERN.matcher(fullUrl);
-		if (matcher.matches() && matcher.groupCount() > 0) {
-			return matcher.group(1);
-		}
-		return null;
 	}
 
 }

--- a/src/main/java/parrot/rest/controller/ForgetController.java
+++ b/src/main/java/parrot/rest/controller/ForgetController.java
@@ -33,7 +33,7 @@ public class ForgetController {
 	private PhraseService phraseService;
 
 	@DeleteMapping("forget/**")
-	public ResponseEntity<String> talk(HttpServletRequest request) {
+	public ResponseEntity<String> forget(HttpServletRequest request) {
 		ResponseEntity<String> result = null;
 		String url = PhraseUtility.getFullUrl(request, URL_PATTERN);
 

--- a/src/main/java/parrot/rest/controller/ForgetController.java
+++ b/src/main/java/parrot/rest/controller/ForgetController.java
@@ -1,0 +1,40 @@
+package parrot.rest.controller;
+
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import parrot.rest.common.Phrase;
+import parrot.rest.exception.UrlNotFoundException;
+import parrot.rest.service.PhraseService;
+
+@Controller(ForgetController.PATH)
+public class ForgetController {
+
+	public static final String PATH = "forget";
+	
+	private static final Logger logger = LoggerFactory.getLogger(ForgetController.class);
+
+	@Autowired
+	private PhraseService phraseService;
+	
+	@DeleteMapping("delete/**")
+	public ResponseEntity<String> forget(@RequestBody Phrase phrase) throws UrlNotFoundException {
+		logger.debug("Deleting phrase: {}", phrase);
+		phraseService.remove(phrase.getUrl());
+		return new ResponseEntity<>("NO_CONTENT", HttpStatus.NO_CONTENT);
+		
+	}
+	
+}
+

--- a/src/main/java/parrot/rest/controller/HealthController.java
+++ b/src/main/java/parrot/rest/controller/HealthController.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package parrot.rest.controller;
 
 import org.springframework.http.HttpStatus;
@@ -16,7 +13,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller("health")
 public class HealthController {
 
-	
 	@GetMapping
 	public ResponseEntity<String> listen() {
 		return new ResponseEntity<>("I'm a healthy parrot, do you have sunflower seeds for me?", HttpStatus.OK);

--- a/src/main/java/parrot/rest/controller/ListenController.java
+++ b/src/main/java/parrot/rest/controller/ListenController.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package parrot.rest.controller;
 
 import org.slf4j.Logger;

--- a/src/main/java/parrot/rest/controller/TalkController.java
+++ b/src/main/java/parrot/rest/controller/TalkController.java
@@ -28,18 +28,18 @@ import parrot.rest.service.PhraseService;
 public class TalkController {
 
 	public static final String PATH = "talk";
-	
+
 	private static final Logger logger = LoggerFactory.getLogger(TalkController.class);
 	private static final Pattern URL_PATTERN = Pattern.compile("\\/{0,1}talk\\/(.*)");
-	
+
 	@Autowired
 	private PhraseService phraseService;
-	
+
 	@GetMapping("talk/**")
 	@ResponseBody
 	public ResponseEntity<String> talk(HttpServletRequest request) throws UrlNotFoundException {
 		String url = getFullUrl(request);
-		
+
 		logger.debug("Talking URL: {}", url);
 		if (StringUtils.isEmpty(url)) {
 			throw new UrlNotFoundException(url);
@@ -47,20 +47,20 @@ public class TalkController {
 		return new ResponseEntity<>(phraseService.getResponse(url), HttpStatus.OK);
 	}
 
-  private String getFullUrl(HttpServletRequest request) {
-    StringBuilder builder = new StringBuilder();
-    String fullUrl = (String)request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
-    String url = getAppContextUrl(fullUrl);
-    if (url == null) {
-      return null;
-    }
-    builder.append(url);    
-    if (StringUtils.isNotEmpty(request.getQueryString())) {
-      builder.append("?");
-      builder.append(request.getQueryString());
-    }
-    return builder.toString();
-  }
+	private String getFullUrl(HttpServletRequest request) {
+		StringBuilder builder = new StringBuilder();
+		String fullUrl = (String) request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
+		String url = getAppContextUrl(fullUrl);
+		if (url == null) {
+			return null;
+		}
+		builder.append(url);
+		if (StringUtils.isNotEmpty(request.getQueryString())) {
+			builder.append("?");
+			builder.append(request.getQueryString());
+		}
+		return builder.toString();
+	}
 
 	private String getAppContextUrl(String fullUrl) {
 		Matcher matcher = URL_PATTERN.matcher(fullUrl);

--- a/src/main/java/parrot/rest/controller/TalkController.java
+++ b/src/main/java/parrot/rest/controller/TalkController.java
@@ -1,6 +1,5 @@
 package parrot.rest.controller;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
@@ -14,8 +13,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.servlet.HandlerMapping;
 
+import parrot.rest.common.PhraseUtility;
 import parrot.rest.exception.UrlNotFoundException;
 import parrot.rest.service.PhraseService;
 
@@ -38,35 +37,12 @@ public class TalkController {
 	@GetMapping("talk/**")
 	@ResponseBody
 	public ResponseEntity<String> talk(HttpServletRequest request) throws UrlNotFoundException {
-		String url = getFullUrl(request);
+		String url = PhraseUtility.getFullUrl(request, URL_PATTERN);
 
 		logger.debug("Talking URL: {}", url);
 		if (StringUtils.isEmpty(url)) {
 			throw new UrlNotFoundException(url);
 		}
 		return new ResponseEntity<>(phraseService.getResponse(url), HttpStatus.OK);
-	}
-
-	private String getFullUrl(HttpServletRequest request) {
-		StringBuilder builder = new StringBuilder();
-		String fullUrl = (String) request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
-		String url = getAppContextUrl(fullUrl);
-		if (url == null) {
-			return null;
-		}
-		builder.append(url);
-		if (StringUtils.isNotEmpty(request.getQueryString())) {
-			builder.append("?");
-			builder.append(request.getQueryString());
-		}
-		return builder.toString();
-	}
-
-	private String getAppContextUrl(String fullUrl) {
-		Matcher matcher = URL_PATTERN.matcher(fullUrl);
-		if (matcher.matches() && matcher.groupCount() > 0) {
-			return matcher.group(1);
-		}
-		return null;
 	}
 }

--- a/src/main/java/parrot/rest/repository/PhraseRepository.java
+++ b/src/main/java/parrot/rest/repository/PhraseRepository.java
@@ -6,7 +6,7 @@ package parrot.rest.repository;
 import parrot.rest.common.Phrase;
 
 /**
- * @author gamezd
+ * @author David Gamez, Isuru Weerasooriya
  *
  */
 public interface PhraseRepository {

--- a/src/main/java/parrot/rest/repository/PhraseRepository.java
+++ b/src/main/java/parrot/rest/repository/PhraseRepository.java
@@ -15,4 +15,6 @@ public interface PhraseRepository {
 	
 	Phrase load(String fullUrl);
 
+	Phrase delete(String fullUrl);
+	
 }

--- a/src/main/java/parrot/rest/repository/PhraseRepositoryBase.java
+++ b/src/main/java/parrot/rest/repository/PhraseRepositoryBase.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 import parrot.rest.common.Phrase;
 
 /**
+ * @author David Gamez
  *
  */
 public abstract class PhraseRepositoryBase  implements PhraseRepository {

--- a/src/main/java/parrot/rest/repository/PhraseRepositoryMapImpl.java
+++ b/src/main/java/parrot/rest/repository/PhraseRepositoryMapImpl.java
@@ -30,4 +30,9 @@ public class PhraseRepositoryMapImpl extends PhraseRepositoryBase {
     return map.get(getIdFromUrl(fullUrl));
   }
 
+  @Override
+  public Phrase delete(String fullUrl) {
+	  return map.remove(getIdFromUrl(fullUrl));
+  }
+  
 }

--- a/src/main/java/parrot/rest/repository/PhraseRepositoryMapImpl.java
+++ b/src/main/java/parrot/rest/repository/PhraseRepositoryMapImpl.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import parrot.rest.common.Phrase;
 
 /**
+ * @author David Gamez, Isuru Weerasooriya
  *
  */
 @Component

--- a/src/main/java/parrot/rest/repository/PhraseRepositoryRedisImpl.java
+++ b/src/main/java/parrot/rest/repository/PhraseRepositoryRedisImpl.java
@@ -37,5 +37,14 @@ public class PhraseRepositoryRedisImpl extends PhraseRepositoryBase {
 		return (Phrase) getHashOps().get(Phrase.class.getName(), getIdFromUrl(url));
 	}
 	
+	@Override
+	public Phrase delete(String url) {
+		Phrase result = load(url);
+		if (result != null) {
+			getHashOps().delete(Phrase.class.getName(), getIdFromUrl(url));
+		}
+		return result;
+	}
+	
 
 }

--- a/src/main/java/parrot/rest/repository/PhraseRepositoryRedisImpl.java
+++ b/src/main/java/parrot/rest/repository/PhraseRepositoryRedisImpl.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 import parrot.rest.common.Phrase;
 
 /**
- * @author David Gamez
+ * @author David Gamez, Isuru Weerasooriya
  *
  */
 @Component
@@ -46,5 +46,4 @@ public class PhraseRepositoryRedisImpl extends PhraseRepositoryBase {
 		return result;
 	}
 	
-
 }

--- a/src/main/java/parrot/rest/service/PhraseService.java
+++ b/src/main/java/parrot/rest/service/PhraseService.java
@@ -15,4 +15,6 @@ public interface PhraseService {
 	Phrase save(Phrase phrase);
 	
 	String getResponse(String url) throws UrlNotFoundException;
+	
+	Phrase remove(String url) throws UrlNotFoundException;
 }

--- a/src/main/java/parrot/rest/service/PhraseServiceImpl.java
+++ b/src/main/java/parrot/rest/service/PhraseServiceImpl.java
@@ -28,6 +28,7 @@ public class PhraseServiceImpl implements PhraseService {
 		return phraseRepository.save(phrase);
 	}
 
+		
 	/* (non-Javadoc)
 	 * @see parrot.rest.repository.PhraseService#get(java.lang.String, java.lang.String)
 	 */
@@ -39,5 +40,15 @@ public class PhraseServiceImpl implements PhraseService {
 		}
 
 		return result.getResponse();
+	}
+
+
+	@Override
+	public Phrase remove(String url) throws UrlNotFoundException {
+		Phrase result = phraseRepository.delete(url);
+		if (result == null) {
+			throw new UrlNotFoundException(url);
+		}
+		return result;
 	}
 }

--- a/src/main/java/parrot/rest/service/PhraseServiceImpl.java
+++ b/src/main/java/parrot/rest/service/PhraseServiceImpl.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package parrot.rest.service;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,8 @@ persistent.type=MAP
 
 #REDIS
 spring.redis.url=http://localhost:6379
+
+---
+# local profile
+spring.profiles=local
+server.port=10010

--- a/src/test/java/parrot/rest/common/FixtureUtility.java
+++ b/src/test/java/parrot/rest/common/FixtureUtility.java
@@ -1,0 +1,23 @@
+package parrot.rest.common;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.web.servlet.HandlerMapping;
+
+public class FixtureUtility {
+
+	private FixtureUtility() {
+
+	}
+
+	public static HttpServletRequest getMockRequest(String url, String parameters) {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		when(request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE)).thenReturn(url);
+		when(request.getQueryString()).thenReturn(parameters);
+		return request;
+	}
+
+}

--- a/src/test/java/parrot/rest/controller/ForgetControllerTest.java
+++ b/src/test/java/parrot/rest/controller/ForgetControllerTest.java
@@ -1,0 +1,56 @@
+package parrot.rest.controller;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import parrot.rest.common.FixtureUtility;
+import parrot.rest.exception.UrlNotFoundException;
+import parrot.rest.service.PhraseService;
+
+/**
+ * @author Isuru Weerasooriya
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ForgetControllerTest {
+
+	@InjectMocks
+	ForgetController fixture;
+
+	@Mock
+	PhraseService phraseService;
+
+	@Test
+	public void testForgetExistingUrl() throws UrlNotFoundException {
+		HttpServletRequest request = FixtureUtility.getMockRequest("forget/appContext/url", "");
+
+		ResponseEntity<String> response = fixture.forget(request);
+
+		verify(phraseService, times(1)).remove("appContext/url");
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testForgetNotExistingUrl() throws UrlNotFoundException {
+		HttpServletRequest request = FixtureUtility.getMockRequest("forget/appContext/url", "");
+
+		when(phraseService.remove("appContext/url")).thenThrow(UrlNotFoundException.class);
+		ResponseEntity<String> response = fixture.forget(request);
+
+		assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+	}
+}

--- a/src/test/java/parrot/rest/controller/ListenTalkMapIT.java
+++ b/src/test/java/parrot/rest/controller/ListenTalkMapIT.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package parrot.rest.controller;
 
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -31,75 +28,69 @@ import parrot.rest.common.Phrase;
 @PropertySource("classpath:application-test-map.properties")
 public class ListenTalkMapIT extends BaseIntegrationController {
 
-  private static final String JSON_RESPONSE = "{\"id\": 1, \"name\": \"Test response\"}";
-  
-  @Autowired
-  ListenController listenController;
+	private static final String JSON_RESPONSE = "{\"id\": 1, \"name\": \"Test response\"}";
 
-  @Autowired
-  WebApplicationContext context;
-  
-  @Before
-  public void setup() {
-    initMocks(this);
-    this.mockMvc = webAppContextSetup(context)
-        .alwaysDo(print()).build();
-  }
-  
-  @After
-  public void validate() {
-    Mockito.validateMockitoUsage();
-  }
-  
-  @Test
-  public void testListenTalkBasic() throws Exception {
-    
-    Phrase phrase = new Phrase();
-    phrase.setAppContext("app_context");
-    phrase.setUrl("the_url");
-    phrase.setResponse(JSON_RESPONSE);
-    
-    Gson gson = new Gson();
-    String json = gson.toJson(phrase);
-    
-//    Listen
-    mockMvc.perform(post("/listen").contentType(MediaType.APPLICATION_JSON).content(json))
-        .andExpect(status().isOk())
-      .andExpect(content().string("OK"));
+	@Autowired
+	ListenController listenController;
 
-//    Talk
-    mockMvc.perform(get("/talk/app_context/the_url"))
-    .andExpect(status().isOk())
-  .andExpect(content().string(JSON_RESPONSE));    
-  }
+	@Autowired
+	WebApplicationContext context;
 
-  @Test
-  public void testListenTalkParameters() throws Exception {
-    
-    Phrase phrase = new Phrase();
-    phrase.setAppContext("app_context");
-    phrase.setUrl("the_url?param=true");
-    phrase.setResponse(JSON_RESPONSE);
-    
-    Gson gson = new Gson();
-    String json = gson.toJson(phrase);
-    
-//    Listen
-    mockMvc.perform(post("/listen").contentType(MediaType.APPLICATION_JSON).content(json))
-        .andExpect(status().isOk())
-      .andExpect(content().string("OK"));
+	@Before
+	public void setup() {
+		initMocks(this);
+		this.mockMvc = webAppContextSetup(context).alwaysDo(print()).build();
+	}
 
-//    Talk
-    mockMvc.perform(get("/talk/app_context/the_url?param=true"))
-    .andExpect(status().isOk())
-  .andExpect(content().string(JSON_RESPONSE));    
-  }
-  
-  @Test
-  public void testListenMissingUrl() throws Exception {
+	@After
+	public void validate() {
+		Mockito.validateMockitoUsage();
+	}
 
-//    Talk
-    mockMvc.perform(get("/talk/no_existing_app_context/the_url"))
-    .andExpect(status().isNotFound());    
-  }
+	@Test
+	public void testListenTalkBasic() throws Exception {
+
+		Phrase phrase = new Phrase();
+		phrase.setAppContext("app_context");
+		phrase.setUrl("the_url");
+		phrase.setResponse(JSON_RESPONSE);
+
+		Gson gson = new Gson();
+		String json = gson.toJson(phrase);
+
+		//    Listen
+		mockMvc.perform(post("/listen").contentType(MediaType.APPLICATION_JSON).content(json))
+				.andExpect(status().isOk()).andExpect(content().string("OK"));
+
+		//    Talk
+		mockMvc.perform(get("/talk/app_context/the_url")).andExpect(status().isOk())
+				.andExpect(content().string(JSON_RESPONSE));
+	}
+
+	@Test
+	public void testListenTalkParameters() throws Exception {
+
+		Phrase phrase = new Phrase();
+		phrase.setAppContext("app_context");
+		phrase.setUrl("the_url?param=true");
+		phrase.setResponse(JSON_RESPONSE);
+
+		Gson gson = new Gson();
+		String json = gson.toJson(phrase);
+
+		//    Listen
+		mockMvc.perform(post("/listen").contentType(MediaType.APPLICATION_JSON).content(json))
+				.andExpect(status().isOk()).andExpect(content().string("OK"));
+
+		//    Talk
+		mockMvc.perform(get("/talk/app_context/the_url?param=true")).andExpect(status().isOk())
+				.andExpect(content().string(JSON_RESPONSE));
+	}
+
+	@Test
+	public void testListenMissingUrl() throws Exception {
+
+		//    Talk
+		mockMvc.perform(get("/talk/no_existing_app_context/the_url")).andExpect(status().isNotFound());
+	}
 }

--- a/src/test/java/parrot/rest/controller/TalkControllerTest.java
+++ b/src/test/java/parrot/rest/controller/TalkControllerTest.java
@@ -1,6 +1,5 @@
 package parrot.rest.controller;
 
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -12,58 +11,51 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.springframework.web.servlet.HandlerMapping;
 
+import parrot.rest.common.FixtureUtility;
 import parrot.rest.exception.UrlNotFoundException;
 import parrot.rest.service.PhraseService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TalkControllerTest {
 
-  @InjectMocks
-  TalkController fixture;
+	@InjectMocks
+	TalkController fixture;
 
-  @Mock
-  PhraseService phraseService;
+	@Mock
+	PhraseService phraseService;
 
-  @Test
-  public void testTalkExistingUrl() throws UrlNotFoundException {
-    HttpServletRequest request = getMockRequest("talk/appContext/url", "");
+	@Test
+	public void testTalkExistingUrl() throws UrlNotFoundException {
+		HttpServletRequest request = FixtureUtility.getMockRequest("talk/appContext/url", "");
 
-    fixture.talk(request);
+		fixture.talk(request);
 
-    verify(phraseService, times(1)).getResponse("appContext/url");
-  }
+		verify(phraseService, times(1)).getResponse("appContext/url");
+	}
 
-  @Test(expected = UrlNotFoundException.class)
-  public void testTalkBadUrlRequest() throws UrlNotFoundException {
-    HttpServletRequest request = getMockRequest("talk", "");
+	@Test(expected = UrlNotFoundException.class)
+	public void testTalkBadUrlRequest() throws UrlNotFoundException {
+		HttpServletRequest request = FixtureUtility.getMockRequest("talk", "");
 
-    fixture.talk(request);
-  }
+		fixture.talk(request);
+	}
 
-  @SuppressWarnings("unchecked")
-  @Test(expected = UrlNotFoundException.class)
-  public void testTalkNotExistingUrl() throws UrlNotFoundException {
-    HttpServletRequest request = getMockRequest("talk/appContext/url", "");
+	@SuppressWarnings("unchecked")
+	@Test(expected = UrlNotFoundException.class)
+	public void testTalkNotExistingUrl() throws UrlNotFoundException {
+		HttpServletRequest request = FixtureUtility.getMockRequest("talk/appContext/url", "");
 
-    when(phraseService.getResponse("appContext/url")).thenThrow(UrlNotFoundException.class);
-    fixture.talk(request);
-  }
+		when(phraseService.getResponse("appContext/url")).thenThrow(UrlNotFoundException.class);
+		fixture.talk(request);
+	}
 
-  @SuppressWarnings("unchecked")
-  @Test(expected = UrlNotFoundException.class)
-  public void testTalkEmptyUrl() throws UrlNotFoundException {
-    HttpServletRequest request = getMockRequest("", "");
+	@SuppressWarnings("unchecked")
+	@Test(expected = UrlNotFoundException.class)
+	public void testTalkEmptyUrl() throws UrlNotFoundException {
+		HttpServletRequest request = FixtureUtility.getMockRequest("", "");
 
-    when(phraseService.getResponse("appContext/url")).thenThrow(UrlNotFoundException.class);
-    fixture.talk(request);
-  }
-
-  private HttpServletRequest getMockRequest(String url, String parameters) {
-    HttpServletRequest request = mock(HttpServletRequest.class);
-    when(request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE)).thenReturn(url);
-    when(request.getQueryString()).thenReturn(parameters);
-    return request;
-  }
+		when(phraseService.getResponse("appContext/url")).thenThrow(UrlNotFoundException.class);
+		fixture.talk(request);
+	}
 }

--- a/src/test/java/parrot/rest/docs/ParrotRestDocumentationTest.java
+++ b/src/test/java/parrot/rest/docs/ParrotRestDocumentationTest.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package parrot.rest.docs;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -8,6 +5,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -36,7 +34,7 @@ import parrot.rest.ParrotRestApplication;
 import parrot.rest.common.Phrase;
 
 /**
- * @author David Gamez
+ * @author David Gamez, Isuru Weerasooriya
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -48,7 +46,7 @@ public class ParrotRestDocumentationTest {
 	public JUnitRestDocumentation restDoc = new JUnitRestDocumentation("target/snippets");
 
 	private static final String JSON_RESPONSE = "{\"id\": 1, \"name\": \"Test response\"}";
-	
+
 	private RestDocumentationResultHandler document;
 	private MockMvc mockMvc;
 
@@ -56,39 +54,65 @@ public class ParrotRestDocumentationTest {
 	private WebApplicationContext context;
 
 	@Autowired
-    private ObjectMapper objectMapper;
-	
+	private ObjectMapper objectMapper;
+
 	@Mock
 	JedisConnectionFactory JedisConnectionFactory;
+
+	private Phrase phrase = new Phrase();
 	
 	@Before
-	public void setUp() {
+	public void setUp() throws Exception {
 		this.document = document("{method-name}", preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint()));
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(this.context).apply(documentationConfiguration(this.restDoc))
 				.alwaysDo(this.document).build();
+		
+		phrase.setAppContext("appContext");
+		phrase.setResponse(JSON_RESPONSE);
+		phrase.setUrl("path");
+
+		setupPhrase();
+	}
+	
+	private void setupPhrase() throws Exception {
+		this.mockMvc.perform(delete("/forget/appContext/path"));
+		
+		this.mockMvc
+		.perform(post("/listen").contentType(MediaTypes.HAL_JSON)
+				.content(this.objectMapper.writeValueAsString(phrase)));
+	}
+	
+	@Test
+	public void listenExample() throws Exception {
+		// Remove setup before we test
+		this.mockMvc.perform(delete("/forget/appContext/path"));
+		
+		this.mockMvc
+		.perform(post("/listen").contentType(MediaTypes.HAL_JSON)
+				.content(this.objectMapper.writeValueAsString(phrase)))
+		.andExpect(status().isOk()).andReturn().getResponse().getContentAsString().equals("OK");
 	}
 
-    @Test
-    public void listenExample() throws Exception {
-    		Phrase phrase = new Phrase();
-    		phrase.setAppContext("appContext");
-    		phrase.setResponse(JSON_RESPONSE);
-    		phrase.setUrl("path");
-    		
-        this.mockMvc.perform(post("/listen").contentType(MediaTypes.HAL_JSON).content(this.objectMapper.writeValueAsString(phrase)))
-        		.andExpect(status().isOk()).andReturn().getResponse().getContentAsString().equals("OK");
-        
-    }
+	
+	@Test
+	public void talkExample() throws Exception {
+		this.mockMvc.perform(get("/talk/appContext/path")).andExpect(status().isOk()).andReturn().getResponse()
+				.getContentAsString().equals(JSON_RESPONSE);
+	}
 
-    @Test
-    public void talkExample() throws Exception {
-        this.mockMvc.perform(get("/talk/appContext/path"))
-        		.andExpect(status().isOk()).andReturn().getResponse().getContentAsString().equals(JSON_RESPONSE);
-    }
-    
-    @Test
-    public void healthExample() throws Exception {
-        this.mockMvc.perform(get("/health"))
-        		.andExpect(status().isOk()).andReturn().getResponse().getContentAsString().equals("I'm a healthy parrot, do you have a sunflower seeds for me?");
-    }
+	@Test
+	public void forgetExample() throws Exception {
+		this.mockMvc.perform(delete("/forget/appContext/path")).andExpect(status().isOk());
+	}
+
+	@Test
+	public void forgetPhaseDoesNotExistExample() throws Exception {
+		this.mockMvc.perform(delete("/forget/appContext/pathDoesNotExist")).andExpect(status().isNoContent());
+	}
+
+	@Test
+	public void healthExample() throws Exception {
+		this.mockMvc.perform(get("/health")).andExpect(status().isOk()).andReturn().getResponse().getContentAsString()
+				.equals("I'm a healthy parrot, do you have a sunflower seeds for me?");
+	}
 }

--- a/src/test/java/parrot/rest/docs/ParrotRestDocumentationTest.java
+++ b/src/test/java/parrot/rest/docs/ParrotRestDocumentationTest.java
@@ -106,7 +106,7 @@ public class ParrotRestDocumentationTest {
 	}
 
 	@Test
-	public void forgetPhaseDoesNotExistExample() throws Exception {
+	public void forgetNonExistingResourceExample() throws Exception {
 		this.mockMvc.perform(delete("/forget/appContext/pathDoesNotExist")).andExpect(status().isNoContent());
 	}
 

--- a/src/test/java/parrot/rest/repository/HashOperationsMock.java
+++ b/src/test/java/parrot/rest/repository/HashOperationsMock.java
@@ -38,7 +38,13 @@ public class HashOperationsMock implements HashOperations<String, Object, Object
 	
 	@Override
 	public Long delete(String key, Object... hashKeys) {
-		throw new UnsupportedOperationException("Unsupported method");
+		Map<Object, Object> valueMap = map.get(key);
+		if (valueMap != null) {
+			for (Object hashKey : hashKeys) {
+				valueMap.remove(hashKey);
+			}
+		}
+		return null;
 	}
 
 	@Override

--- a/src/test/java/parrot/rest/repository/PhraseRepositoryBaseTest.java
+++ b/src/test/java/parrot/rest/repository/PhraseRepositoryBaseTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mockito;
 import parrot.rest.common.Phrase;
 
 /**
+ * @author David Gamez
  *
  */
 public class PhraseRepositoryBaseTest {

--- a/src/test/java/parrot/rest/repository/PhraseRepositoryRedisImplTest.java
+++ b/src/test/java/parrot/rest/repository/PhraseRepositoryRedisImplTest.java
@@ -20,7 +20,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import parrot.rest.common.Phrase;
 
 /**
- * @author David Gamez
+ * @author David Gamez, Isuru Weerasooriy
  *
  */
 @RunWith(MockitoJUnitRunner.class)
@@ -55,6 +55,21 @@ public class PhraseRepositoryRedisImplTest {
 		assertEquals(phrase, opsHash.get(Phrase.class.getName(), fixture.getId(phrase)));
 		
 		assertEquals(phrase, fixture.load(fixture.getId(phrase)));
+	}
+	
+	@Test
+	public void testSaveDeleteLoad() {
+		Phrase phrase = new Phrase();
+		phrase.setAppContext("appTest");
+		phrase.setUrl("url");
+		
+		assertNull(fixture.load(fixture.getId(phrase)));
+		
+		fixture.save(phrase);
+		assertNotNull(opsHash.get(Phrase.class.getName(), fixture.getId(phrase)));
+		
+		fixture.delete("appTest/url");
+		assertNull(opsHash.get(Phrase.class.getName(), fixture.getId(phrase)));
 	}
 	
 }


### PR DESCRIPTION
# Parrot-REST Pull Request

 - [ ] Code local build green
 - [ ] Reasonable unit and integration tests added

##What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring 
- [ ] Build / CI related changes
- [ ] Other... Please describe:

## Description of the changes
Added support for HTTP DELETE method. Can be invoked using keyword `forget`.

## Related issues
[Add support to HTTP POST, DELETE, PUT methods](https://github.com/davidgamez/parrot-rest/issues/7)